### PR TITLE
Melter skip binary padding values

### DIFF
--- a/src/de/hashmap_f64.rs
+++ b/src/de/hashmap_f64.rs
@@ -1,0 +1,44 @@
+use serde::{de, de::IgnoredAny, Deserialize, Deserializer};
+use std::collections::HashMap;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum MaybeF64 {
+    F64(f64),
+    Other(IgnoredAny),
+}
+
+pub fn deserialize_hashmap_f64<'de, D>(deserializer: D) -> Result<HashMap<String, f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = HashMap<String, f64>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map with string keys and numeric values")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut values = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                match map.next_value::<MaybeF64>()? {
+                    MaybeF64::F64(v) => {
+                        values.insert(key, v);
+                    }
+                    MaybeF64::Other(_) => {
+                        // Skip non-f64 values (lists, objects, etc.)
+                    }
+                }
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_map(Visitor)
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,3 +1,5 @@
+mod hashmap_f64;
 mod vec_pair;
 
+pub use hashmap_f64::*;
 pub use vec_pair::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,7 @@
-use crate::{de::deserialize_vec_pair, CountryTag, Hoi4Date};
+use crate::{
+    de::{deserialize_hashmap_f64, deserialize_vec_pair},
+    CountryTag, Hoi4Date,
+};
 use jomini::JominiDeserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -17,6 +20,6 @@ pub struct Country {
     pub stability: f64,
     #[jomini(default)]
     pub war_support: f64,
-    #[jomini(default)]
+    #[jomini(default, deserialize_with = "deserialize_hashmap_f64")]
     pub variables: HashMap<String, f64>,
 }


### PR DESCRIPTION
Encountering some weird syntax:

- `Id(0) = Id(0)`
- `Id(0xFFFF) = id(0xFFFF)`
- `{ 0 Id(0) 0 Id(0) }`

Just skipping them for now as the plaintext output doesn't appear any different.

Also updated variables deserialization to skip non-f64 values