### PR TITLE
HOI4 1.17 compatible melter

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,9 @@ pub enum Hoi4ErrorKind {
     #[error("country tags must contain only ascii letters")]
     CountryTagInvalidCharacters,
 
+    #[error("unexpected end of file")]
+    Eof,
+
     #[error("io error: {0}")]
     Io(#[from] io::Error),
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -194,9 +194,9 @@ impl Hoi4FsFile {
         Resolver: TokenResolver,
         Writer: Write,
     {
+        output.write_all(b"HOI4txt")?;
         match &mut self.kind {
             Hoi4FsFileKind::Text(file) => {
-                output.write_all(b"HOI4txt")?;
                 std::io::copy(&mut file.0, &mut output)?;
                 Ok(MeltedDocument::new())
             }


### PR DESCRIPTION
HOI4 binary does not follow any PDS binary format as the 32bit field has been widen to 64bits. Thus I decided just to inline the parsing.

We detect the save format and branch accordingly when new tokens are seen.